### PR TITLE
Fix nmap plugins handing of "NOT VULNERABLE" tag

### DIFF
--- a/faraday_plugins/plugins/repo/nmap/plugin.py
+++ b/faraday_plugins/plugins/repo/nmap/plugin.py
@@ -511,7 +511,7 @@ class NmapPlugin(PluginXMLFormat):
                     desc = v.desc
                     refs = v.refs
 
-                    if re.search(r"VULNERABLE", desc):
+                    if re.search(r"(?<!NOT )VULNERABLE", desc):
                         severity = "high"
                     if re.search(r"ERROR", desc):
                         severity = "unclassified"


### PR DESCRIPTION
Currently, nmap plugin does not handle vulnerability script scan results correctly, because it is setting a severity of "high" depending on this line:

plugin.py:514
```
if re.search(r"VULNERABLE", desc):
    severity = "high"
```

This line matches following tags:
- VULNERABLE
- LIKELY VULNERABLE
- NOT VULNERABLE

Added a negative lookbehind for "NOT".

plugin.py:514
```
if re.search(r"(?<!NOT )VULNERABLE", desc):
```

Following is an example of false positive high's set by the plugin.
![image](https://user-images.githubusercontent.com/16636092/82423206-28460d80-9a8c-11ea-8651-68d6b86108d4.png)
