### PR TITLE
Added SonarQube API report

### DIFF
--- a/faraday_plugins/plugins/repo/sonarqubeapi/__init__.py
+++ b/faraday_plugins/plugins/repo/sonarqubeapi/__init__.py
@@ -1,0 +1,5 @@
+"""
+Faraday Penetration Test IDE
+Copyright (C) 2013  Infobyte LLC (http://www.infobytesec.com/)
+See the file 'doc/LICENSE' for the license information
+"""

--- a/faraday_plugins/plugins/repo/sonarqubeapi/plugin.py
+++ b/faraday_plugins/plugins/repo/sonarqubeapi/plugin.py
@@ -1,0 +1,104 @@
+"""
+Faraday Penetration Test IDE
+Copyright (C) 2021  Infobyte LLC (http://www.infobytesec.com/)
+See the file 'doc/LICENSE' for the license information
+
+"""
+import json
+from faraday_plugins.plugins.plugin import PluginJsonFormat
+from datetime import datetime
+
+VULNERABILITY = "VULNERABILITY"
+
+# ATTENTION: The following mappings are created following the common sense in order to integrate F! with SQ. You
+# can see what term means in the following website: https://docs.sonarqube.org/latest/user-guide/issues/
+SEVERITIES = {
+    'INFO': 'unclassified',
+    'MINOR': 'low',
+    'MAJOR': 'medium',
+    'CRITICAL': 'high',
+    'BLOCKER': 'critical'
+}
+STATUSES = {
+    'OPEN': 'open',
+    'CONFIRMED': 'opened',
+    'REOPENED': 're-opened',
+    'CLOSED': 'closed',
+    'RESOLVED': 'closed'
+}
+
+
+class SonarQubeAPIParser:
+    def __init__(self, json_output):
+        json_data = json.loads(json_output)
+
+        self.vulns = self._parse_vulns(json_data)
+
+    def _parse_vulns(self, json_data):
+        vulns = []
+
+        for issue in json_data['issues']:
+            if issue['type'] != VULNERABILITY:
+                continue
+
+            name = issue['rule']
+            path = issue['component']
+            severity = SEVERITIES[issue['severity']]
+            message = issue['message']
+            status = STATUSES[issue['status']]
+            tags = issue['tags']
+            creation_date = datetime.strptime(issue['creationDate'], '%Y-%m-%dT%H:%M:%S%z')
+
+            vulns.append(
+                {'name': name, 'path': path, 'message': message, 'severity': severity, "status": status, 'tags': tags,
+                 'creation_date': creation_date})
+
+        return vulns
+
+
+class SonarQubeAPIPlugin(PluginJsonFormat):
+    def __init__(self, *arg, **kwargs):
+        super().__init__(*arg, **kwargs)
+        self.identifier_tag = "sonarqube-api"
+        self.id = "SonarQubeAPI"
+        self.name = "SonarQube API Plugin"
+        self.plugin_version = "0.0.1"
+
+    def report_belongs_to(self, **kwargs):
+        if super().report_belongs_to(**kwargs):
+            report_path = kwargs.get("report_path", "")
+            with open(report_path) as f:
+                output = f.read()
+                json_data = json.loads(output)
+
+                has_total = json_data.get('total', None) is not None
+                has_p = json_data.get('p', None) is not None
+                has_ps = json_data.get('ps', None) is not None
+                has_paging = json_data.get('paging', None) is not None
+                has_effort_total = json_data.get('effortTotal', None) is not None
+                has_issues = json_data.get('issues', None) is not None
+                has_components = json_data.get('components', None) is not None
+                has_facets = json_data.get('facets', None) is not None
+
+                return has_total and has_p and has_ps and has_paging and has_effort_total and has_issues and has_components and has_facets
+
+        return False
+
+    def parseOutputString(self, output, debug=False):
+        parser = SonarQubeAPIParser(output)
+        for vuln in parser.vulns:
+            host_id = self.createAndAddHost(vuln['path'])
+
+            self.createAndAddVulnToHost(
+                host_id=host_id,
+                name=vuln['name'],
+                desc=vuln['message'],
+                status=vuln['status'],
+                run_date=vuln['creation_date'],
+                severity=vuln['severity'],
+                tags=vuln['tags']
+            )
+
+
+def createPlugin(ignore_info=False):
+    return SonarQubeAPIPlugin(ignore_info=ignore_info)


### PR DESCRIPTION
In this PR I'm creating a Sonar Qube API report plugin.

Before reading the code, please read the following considerations:

- Sonar Qube does not include some export reports as XML or JSON in the UI. For that reason, I've checked how it was implemented in DefectDojo and I worked based on that.
- Before getting into DefectDojo code, I tried to find the history of the SonarQube report and how it was implemented. I found the following discussions: https://jira.sonarsource.com/browse/MMF-1672 and https://github.com/DefectDojo/django-DefectDojo/issues/810
- Wrapping up the previous discussions, the SonarQube team wanted to create the plugin in DefectDojo using their generic import but it finally wasn't implemented by them because DefectDojo detects that generic import couldn't say that the report belongs to SonarQube. It means that integration could be SonarQube --> Defect Dojo
- Then SonarQube team suggested let the DefectDojo team create the plugin using Sonar Qube API giving them some explanation about how the API work (read the JIRA ticket)
- DefectDojo implemented two versions on SonarQube report: One of them using the API and the other version using an external SonarQube HTML report (https://github.com/soprasteria/sonar-report).

Knowing the context I followed these considerations:
- This plugin will not connect with SonarQubeAPI because it needs the API Key, it only will read the JSON provided after making the request to the API
- The previous note means that the consumer needs to understand the SonarQube API and needs to know that the max page size is 500 items, so maybe needs to automate the pagination behavior generating one big JSON file or generating multiple JSON files to be uploaded in Faraday!
- You can see a JSON example in [this url](https://next.sonarqube.com/sonarqube/api/issues/search?statuses=OPEN%2CREOPENED%2CCONFIRMED&types=VULNERABILITY&ps=500)
- I skipped the implementation of the report based on HTML SonarQube report because that SonarQube plugin uses the SonarQube API too.

Some specific comments about the implementation:
- Severities and Status between Faraday and SonarQube are not the same, so in the plugin file I created some mapping that could change if you think that they are not correct. You can see [this URL](https://docs.sonarqube.org/latest/user-guide/issues/) with SonarQube data
- I skipped all issue that is not VULNERABILITY (SonarQube recognizes Code Smells, bugs, and vulnerabilities)


Let me know if you need more info about it.

PD: Here you can see an image of the uploaded report

![image](https://user-images.githubusercontent.com/1610232/117602057-2acec680-b126-11eb-8a42-c1200aed9dce.png)


Thanks

