### PR TITLE
Added python and python3 to processCommandString

### DIFF
--- a/faraday_plugins/plugins/plugin.py
+++ b/faraday_plugins/plugins/plugin.py
@@ -274,7 +274,7 @@ class PluginBase:
         command that it's going to be executed.
         """
         self._current_path = current_path
-        if command_string.startswith("sudo"):
+        if command_string.startswith(("sudo","python","python3")):
             params = " ".join(command_string.split()[2:])
         else:
             params = " ".join(command_string.split()[1:])


### PR DESCRIPTION
Added python and python3 into the processCommandString which currently only grabs sudo to pull in as part of the command. Found that when using tools that require python in the front get logged into the console in an unclean way as the plugin looks for "python3 whatever.py" but the commandString gets logged as just python3. So in the gui the command shows up as "python3 whatever.py whatever.py" but this fixes that issue.