### PR TITLE
openvas: add log to info mapping

### DIFF
--- a/faraday_plugins/plugins/repo/openvas/plugin.py
+++ b/faraday_plugins/plugins/repo/openvas/plugin.py
@@ -207,6 +207,8 @@ class Item:
         severity = self.get_text_from_subnode('threat')
         if severity == 'Alarm':
             severity = 'Critical'
+        if severity == 'Log':
+            severity = 'Info'
         return severity
 
     def get_service(self, port_string, port, details_from_host):


### PR DESCRIPTION
I'm using the greenbone security scanner which is based on openvas.

Greenbone is using the severity label "Log" which has to be translated to "Info".
