### PR TITLE
Remove distutils from Burp plugin

### DIFF
--- a/faraday_plugins/plugins/repo/burp/plugin.py
+++ b/faraday_plugins/plugins/repo/burp/plugin.py
@@ -7,7 +7,6 @@ See the file 'doc/LICENSE' for the license information
 import binascii
 import re
 import base64
-import distutils.util  # pylint: disable=import-error
 from urllib.parse import urlsplit
 import lxml.etree as ET
 
@@ -24,6 +23,15 @@ __version__ = "1.1.0"
 __maintainer__ = "Francisco Amato"
 __email__ = "famato@infobytesec.com"
 __status__ = "Development"
+
+
+def strtobool(value):
+    normalized = value.lower()
+    if normalized in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    if normalized in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    raise ValueError(f"invalid truth value {value!r}")
 
 
 class BurpXmlParser:
@@ -158,7 +166,7 @@ class Item:
         it has it.
         """
         if node is not None:
-            encoded = distutils.util.strtobool(node.get('base64', 'false'))
+            encoded = strtobool(node.get('base64', 'false'))
             if encoded:
                 text = node.text or ""
                 text += "=" * (-len(text) % 4)

--- a/tests/test_burp.py
+++ b/tests/test_burp.py
@@ -1,0 +1,26 @@
+import lxml.etree as ET
+
+from faraday_plugins.plugins.repo.burp.plugin import Item, strtobool
+
+
+def test_decode_binary_node_keeps_plain_text():
+    node = ET.fromstring("<request base64='false'>plain text</request>")
+    item = Item.__new__(Item)
+
+    assert item.decode_binary_node(node) == "plain text"
+
+
+def test_decode_binary_node_decodes_base64_text():
+    node = ET.fromstring("<request base64='true'>cGxhaW4gdGV4dA==</request>")
+    item = Item.__new__(Item)
+
+    assert item.decode_binary_node(node) == "plain text"
+
+
+def test_strtobool_rejects_invalid_values():
+    try:
+        strtobool("maybe")
+    except ValueError as exc:
+        assert "invalid truth value 'maybe'" == str(exc)
+    else:
+        raise AssertionError("ValueError was not raised")


### PR DESCRIPTION
## Summary
- Replace the Burp plugin's `distutils.util.strtobool` call with a local boolean parser.
- Keep the accepted boolean string values compatible with the previous `strtobool` behavior.
- Add focused coverage for Burp request/response binary node decoding and invalid boolean values.

Fixes #35

## Validation
- `git diff --check HEAD~1..HEAD`
- Not run locally: test suite, pre-commit
