### PR TITLE
Preserve Shodan CVSS severity

### DIFF
--- a/faraday_plugins/plugins/repo/shodan/plugin.py
+++ b/faraday_plugins/plugins/repo/shodan/plugin.py
@@ -73,8 +73,17 @@ class ShodanPlugin(PluginMultiLineJsonFormat):
                 for name, vuln_info in vulns.items():
                     description = vuln_info.get('summary')
                     references = vuln_info.get('references')
-                    self.createAndAddVulnToService(h_id, s_id, name, desc=description, ref=references
-                                                   , cve=name)
+                    cvss_score = vuln_info.get('cvss')
+                    cvss2 = {}
+                    severity = vuln_info.get('severity', '')
+                    if cvss_score is not None:
+                        cvss2['base_score'] = cvss_score
+                        if not severity:
+                            severity = get_severity_from_cvss(cvss_score)
+                    self.createAndAddVulnToService(
+                        h_id, s_id, name, desc=description, ref=references,
+                        cve=name, severity=severity, cvss2=cvss2
+                    )
 
     def processCommandString(self, username, current_path, command_string):
         """

--- a/tests/test_shodan.py
+++ b/tests/test_shodan.py
@@ -1,0 +1,32 @@
+import json
+from unittest.mock import Mock
+
+from faraday_plugins.plugins.repo.shodan.plugin import ShodanPlugin
+
+
+def test_shodan_preserves_cvss_score_and_derives_severity():
+    plugin = ShodanPlugin()
+    plugin.createAndAddHost = Mock(return_value="host-id")
+    plugin.createAndAddServiceToHost = Mock(return_value="service-id")
+    plugin.createAndAddVulnToService = Mock()
+
+    plugin.parseOutputString(json.dumps({
+        "ip_str": "203.0.113.10",
+        "port": 443,
+        "transport": "tcp",
+        "hostnames": ["example.test"],
+        "vulns": {
+            "CVE-2024-12345": {
+                "summary": "Example Shodan vulnerability",
+                "references": ["https://example.test/CVE-2024-12345"],
+                "cvss": 7.5,
+            },
+        },
+    }))
+
+    plugin.createAndAddVulnToService.assert_called_once()
+    args, kwargs = plugin.createAndAddVulnToService.call_args
+    assert args[:3] == ("host-id", "service-id", "CVE-2024-12345")
+    assert kwargs["severity"] == "high"
+    assert kwargs["cvss2"] == {"base_score": 7.5}
+    assert kwargs["cve"] == "CVE-2024-12345"


### PR DESCRIPTION
## Summary
- preserve Shodan `cvss` data as `cvss2.base_score` when creating service vulnerabilities
- derive severity from the Shodan CVSS score when no explicit severity is provided
- add a parser regression for Shodan CVSS/severity handling

Fixes #38

## Validation
- `git diff --check`
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`
- `rg` inspection of Shodan CVSS/severity paths
- Not run locally